### PR TITLE
update dependency and adjust module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<version.timingframework>7.3.1</version.timingframework>
 		<version.lucene>9.0.0</version.lucene>
 		<version.paho-mqtt>1.2.5</version.paho-mqtt>
-		<version.diff-match-patch>1.1</version.diff-match-patch>
+		<version.diff-match-patch>1.2</version.diff-match-patch>
 		<version.guava>31.1-jre</version.guava>
 		<version.gson>2.9.0</version.gson>
 		<version.junit>4.13.2</version.junit>
@@ -178,7 +178,7 @@
 		  <artifactId>diff-match-patch</artifactId>
 		  <version>${version.diff-match-patch}</version>
 		</dependency>
-						
+
 
 		<!-- logging -->
 		<dependency>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -28,7 +28,8 @@ open module org.zephyrsoft.sdb2 {
 	requires timingframework.swing;
 	// for togglz:
 	requires java.scripting;
+	
 	requires org.eclipse.paho.client.mqttv3;
-	requires diff.match.patch;
+	requires org.bitbucket.cowwoc.diffmatchpatch;
 	
 }


### PR DESCRIPTION
@l-spiecker Is there a reason why we shouldn't use the latest version of this library?