### PR TITLE
fix:  message encoding

### DIFF
--- a/src/main/java/org/zephyrsoft/sdb2/remote/Health.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/Health.java
@@ -15,7 +15,23 @@
  */
 package org.zephyrsoft.sdb2.remote;
 
+import java.io.UnsupportedEncodingException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public enum Health {
 	online,
 	offline;
+	
+	private static final Logger LOG = LoggerFactory.getLogger(Health.class);
+	
+	public static Health valueOfBytes(byte[] bytes) {
+		try {
+			return Health.valueOf(new String(bytes, "UTF-8"));
+		} catch (UnsupportedEncodingException e) {
+			LOG.warn("Convert bytes to health failed", e);
+		}
+		return null;
+	}
 }

--- a/src/main/java/org/zephyrsoft/sdb2/remote/MQTT.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/MQTT.java
@@ -78,7 +78,9 @@ public class MQTT implements MqttCallback {
 	@Override
 	public void messageArrived(String topic, MqttMessage message) throws Exception {
 		LOG.debug("Got message: {}", topic);
-		onMessageListeners.forEach(oml -> oml.onMessage(topic, message.toString()));
+		onMessageListeners.forEach(oml -> {
+			oml.onMessage(topic, message.getPayload());
+		});
 	}
 	
 	@Override
@@ -91,11 +93,14 @@ public class MQTT implements MqttCallback {
 		client.subscribe(topic, qos);
 	}
 	
-	public void publish(String topic, String payload, int qos, boolean retained) {
+	public void publish(String topic, byte[] payload, int qos, boolean retained) {
+		if (payload == null) {
+			return;
+		}
 		if (client.isConnected()) {
 			LOG.debug("Publishing message: {}", topic);
 			try {
-				client.publish(topic, payload.getBytes(), qos, retained);
+				client.publish(topic, payload, qos, retained);
 			} catch (Exception e) {
 				// only log the exception
 				LOG.warn("could not publish message", e);
@@ -127,7 +132,7 @@ public class MQTT implements MqttCallback {
 	}
 	
 	public interface OnMessageListener {
-		public abstract void onMessage(String topic, String message);
+		public abstract void onMessage(String topic, byte[] message);
 	}
 	
 	public void onConnectionLost(OnConnectionLostListener onConnectionLostListener) {

--- a/src/main/java/org/zephyrsoft/sdb2/remote/MqttObject.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/MqttObject.java
@@ -175,9 +175,9 @@ public class MqttObject<T> {
 				if (subTopicSplit[i].equals("+") || subTopicSplit[i].equals("#"))
 					newWildcardPositions.add(i);
 			}
-			this.wildcardPositions = newWildcardPositions.toArray(new Integer[0]);
+			wildcardPositions = newWildcardPositions.toArray(new Integer[0]);
 		} else {
-			this.wildcardPositions = new Integer[] {};
+			wildcardPositions = new Integer[] {};
 		}
 		
 		String newPublishTopic = publishTopic != null ? publishTopic : this.subscriptionTopic;

--- a/src/main/java/org/zephyrsoft/sdb2/remote/MqttObject.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/MqttObject.java
@@ -15,6 +15,7 @@
  */
 package org.zephyrsoft.sdb2.remote;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiPredicate;
@@ -28,107 +29,107 @@ import org.slf4j.LoggerFactory;
 public class MqttObject<T> {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(MqttObject.class);
-
+	
 	private final Integer[] wildcardPositions;
 	private T object;
-    private final String subscriptionTopic;
-    private final String publishTopic;
-    private final int qos;
-    private final boolean retained;
+	private final String subscriptionTopic;
+	private final String publishTopic;
+	private final int qos;
+	private final boolean retained;
 	private MQTT mqtt;
-    private final Function<String, T> toObject;
-    private final Function<T, String> toString;
-    private final BiPredicate<T, T> takeObject;
-    private final BiPredicate<T, T> objectEquals;
-    private final CopyOnWriteArrayList<OnChangeListener<T>> onChangeListeners = new CopyOnWriteArrayList<>();
-    private final CopyOnWriteArrayList<OnChangeListener<T>> onRemoteChangeListeners = new CopyOnWriteArrayList<>();
-    private static final String TAG = MQTT.class.getName();
-    private boolean setDirect = false;
-    private final MQTT.OnMessageListener onMessageListener;
+	private final Function<byte[], T> toObject;
+	private final Function<T, byte[]> toPayload;
+	private final BiPredicate<T, T> takeObject;
+	private final BiPredicate<T, T> objectEquals;
+	private final CopyOnWriteArrayList<OnChangeListener<T>> onChangeListeners = new CopyOnWriteArrayList<>();
+	private final CopyOnWriteArrayList<OnChangeListener<T>> onRemoteChangeListeners = new CopyOnWriteArrayList<>();
+	private static final String TAG = MQTT.class.getName();
+	private boolean setDirect = false;
+	private final MQTT.OnMessageListener onMessageListener;
 	
 	/**
 	 * A simple MQTT based property for synchronizing java objects.
-     * <p>
-     * It can be used for Publish or Subscribe only, Publish&Subscribe on the same topic, or Publish&Subscribe on
-     * separate topics.
-     * <p>
-     * A initially set object which is not null will be published before subscribe is called. Null objects are
-     * supported,
-     * if toObject, takeObject, toString and objectEquals are supporting it. Use case might be a retained message which
-     * can be null, if not set. toString must create a empty String to unset it. Attention: subcribers may not get the
-     * empty string.
-     *
-     * @param mqtt
-     * @param subscriptionTopic
-     * @param toObject
-     * @param toString
-     * @param qos
-     * @param retained
-     * @param objectEquals
-     * @throws MqttException
-     */
-    public MqttObject(MQTT mqtt,
-                      String subscriptionTopic,
-                      Function<String, T> toObject,
-                      Function<T, String> toString,
-                      int qos,
-                      boolean retained,
-                      BiPredicate<T, T> objectEquals) throws MqttException {
-        this(mqtt,
-                null,
-                subscriptionTopic,
-                toObject,
-                null,
-                null,
-                toString,
-                qos,
-                retained,
-                objectEquals,
-                false);
-    }
-
-    /**
-     * A simple MQTT based property for synchronizing java objects.
-     * <p>
+	 * <p>
 	 * It can be used for Publish or Subscribe only, Publish&Subscribe on the same topic, or Publish&Subscribe on
 	 * separate topics.
-     * <p>
+	 * <p>
 	 * A initially set object which is not null will be published before subscribe is called. Null objects are
 	 * supported,
 	 * if toObject, takeObject, toString and objectEquals are supporting it. Use case might be a retained message which
 	 * can be null, if not set. toString must create a empty String to unset it. Attention: subcribers may not get the
 	 * empty string.
 	 *
-     * @param mqtt
-     * @param publishTopic
-     * @param qos
-     * @param retained
+	 * @param mqtt
+	 * @param subscriptionTopic
+	 * @param toObject
+	 * @param toString
+	 * @param qos
+	 * @param retained
+	 * @param objectEquals
 	 * @throws MqttException
 	 */
-    public MqttObject(MQTT mqtt,
-                      String publishTopic,
-                      Function<T, String> toString,
-                      int qos,
-                      boolean retained) throws MqttException {
-        this(mqtt,
-                null,
-                null,
-                null,
-                null,
-                publishTopic,
-                toString,
-                qos,
-                retained,
-                null,
-                false);
+	public MqttObject(MQTT mqtt,
+		String subscriptionTopic,
+		Function<byte[], T> toObject,
+		Function<T, byte[]> toString,
+		int qos,
+		boolean retained,
+		BiPredicate<T, T> objectEquals) throws MqttException {
+		this(mqtt,
+			null,
+			subscriptionTopic,
+			toObject,
+			null,
+			null,
+			toString,
+			qos,
+			retained,
+			objectEquals,
+			false);
 	}
 	
 	/**
 	 * A simple MQTT based property for synchronizing java objects.
-     * <p>
+	 * <p>
 	 * It can be used for Publish or Subscribe only, Publish&Subscribe on the same topic, or Publish&Subscribe on
 	 * separate topics.
-     * <p>
+	 * <p>
+	 * A initially set object which is not null will be published before subscribe is called. Null objects are
+	 * supported,
+	 * if toObject, takeObject, toString and objectEquals are supporting it. Use case might be a retained message which
+	 * can be null, if not set. toString must create a empty String to unset it. Attention: subcribers may not get the
+	 * empty string.
+	 *
+	 * @param mqtt
+	 * @param publishTopic
+	 * @param qos
+	 * @param retained
+	 * @throws MqttException
+	 */
+	public MqttObject(MQTT mqtt,
+		String publishTopic,
+		Function<T, byte[]> toString,
+		int qos,
+		boolean retained) throws MqttException {
+		this(mqtt,
+			null,
+			null,
+			null,
+			null,
+			publishTopic,
+			toString,
+			qos,
+			retained,
+			null,
+			false);
+	}
+	
+	/**
+	 * A simple MQTT based property for synchronizing java objects.
+	 * <p>
+	 * It can be used for Publish or Subscribe only, Publish&Subscribe on the same topic, or Publish&Subscribe on
+	 * separate topics.
+	 * <p>
 	 * A initially set object which is not null will be published before subscribe is called. Null objects are
 	 * supported,
 	 * if toObject, takeObject, toString and objectEquals are supporting it. Use case might be a retained message which
@@ -138,58 +139,65 @@ public class MqttObject<T> {
 	 * @throws MqttException
 	 */
 	public MqttObject(MQTT mqtt,
-					  T object,
-					  String subscriptionTopic,
-					  Function<String, T> toObject,
-					  BiPredicate<T, T> takeObject,
-					  String publishTopic,
-					  Function<T, String> toString,
-					  int qos,
-					  boolean retained,
-					  BiPredicate<T, T> objectEquals,
-					  boolean setDirect) throws MqttException {
+		T object,
+		String subscriptionTopic,
+		Function<byte[], T> toObject,
+		BiPredicate<T, T> takeObject,
+		String publishTopic,
+		Function<T, byte[]> toPayload,
+		int qos,
+		boolean retained,
+		BiPredicate<T, T> objectEquals,
+		boolean setDirect) throws MqttException {
 		LOG.trace("new MqttObject: S: {} P: {}", subscriptionTopic, publishTopic);
 		this.subscriptionTopic = subscriptionTopic;
 		this.toObject = toObject;
 		this.takeObject = takeObject;
-        this.toString = toString != null ? toString : Object::toString;
+		this.toPayload = toPayload != null ? toPayload : (s) -> {
+			try {
+				return s.toString().getBytes("UTF-8");
+			} catch (UnsupportedEncodingException e) {
+				LOG.warn("Convert object to utf-8 payload failed", e);
+			}
+			return null;
+		};
 		this.qos = qos;
 		this.retained = retained;
-        this.objectEquals = objectEquals != null ? objectEquals : (a, b) -> a == null ? b == null : a.equals(b);
+		this.objectEquals = objectEquals != null ? objectEquals : (a, b) -> a == null ? b == null : a.equals(b);
 		this.object = object;
-        this.setDirect = setDirect;
-
-        if (this.subscriptionTopic != null && (this.subscriptionTopic.contains("+") || this.subscriptionTopic.contains("#"))) {
-            String[] subTopicSplit = this.subscriptionTopic.split("/");
-            ArrayList<Integer> wildcardPositions = new ArrayList<>(subTopicSplit.length);
-            for (int i = 0; i < subTopicSplit.length; i++) {
-                if (subTopicSplit[i].equals("+") || subTopicSplit[i].equals("#"))
-                    wildcardPositions.add(i);
-            }
-            this.wildcardPositions = wildcardPositions.toArray(new Integer[0]);
-        } else {
-            wildcardPositions = new Integer[]{};
-        }
-
-        publishTopic = publishTopic != null ? publishTopic : this.subscriptionTopic;
-        if (publishTopic.contains("+") || publishTopic.contains("#")) {
-            String[] pubTopicSplit = publishTopic.split("/");
-            for (int i = 0; i < pubTopicSplit.length; i++) {
-                if (pubTopicSplit[i].equals("+") || pubTopicSplit[i].equals("#"))
-                    pubTopicSplit[i] = "%s";
-            }
-            publishTopic = String.join("/", pubTopicSplit);
-        }
-        this.publishTopic = publishTopic;
-
-        onMessageListener = (topic, message) -> {
-            if (this.subscriptionTopic != null && MqttTopic.isMatched(this.subscriptionTopic, topic)) {
-                T newObject = this.toObject == null ? (T) message : this.toObject.apply(message);
-                if (this.takeObject != null && !this.takeObject.test(this.object, newObject))
-                    return;
-                set(newObject, true, (Object[]) getArgsFromTopic(topic));
-            }
-        };
+		this.setDirect = setDirect;
+		
+		if (this.subscriptionTopic != null && (this.subscriptionTopic.contains("+") || this.subscriptionTopic.contains("#"))) {
+			String[] subTopicSplit = this.subscriptionTopic.split("/");
+			ArrayList<Integer> wildcardPositions = new ArrayList<>(subTopicSplit.length);
+			for (int i = 0; i < subTopicSplit.length; i++) {
+				if (subTopicSplit[i].equals("+") || subTopicSplit[i].equals("#"))
+					wildcardPositions.add(i);
+			}
+			this.wildcardPositions = wildcardPositions.toArray(new Integer[0]);
+		} else {
+			wildcardPositions = new Integer[] {};
+		}
+		
+		publishTopic = publishTopic != null ? publishTopic : this.subscriptionTopic;
+		if (publishTopic.contains("+") || publishTopic.contains("#")) {
+			String[] pubTopicSplit = publishTopic.split("/");
+			for (int i = 0; i < pubTopicSplit.length; i++) {
+				if (pubTopicSplit[i].equals("+") || pubTopicSplit[i].equals("#"))
+					pubTopicSplit[i] = "%s";
+			}
+			publishTopic = String.join("/", pubTopicSplit);
+		}
+		this.publishTopic = publishTopic;
+		
+		onMessageListener = (topic, message) -> {
+			if (this.subscriptionTopic != null && MqttTopic.isMatched(this.subscriptionTopic, topic)) {
+				T newObject = this.toObject == null ? (T) message : this.toObject.apply(message);
+				if (this.takeObject != null && !this.takeObject.test(this.object, newObject))
+					return;
+				set(newObject, true, (Object[]) getArgsFromTopic(topic));
+			}
+		};
 		
 		connectTo(mqtt);
 	}
@@ -201,49 +209,50 @@ public class MqttObject<T> {
 		subscribe();
 	}
 	
-    public void set(T pObject, Object... args) {
-        set(pObject, false, args);
+	public void set(T pObject, Object... args) {
+		set(pObject, false, args);
 	}
 	
-    private void set(T pObject, boolean fromRemote, Object... args) {
+	private void set(T pObject, boolean fromRemote, Object... args) {
 		if (pObject == object || objectEquals.test(pObject, object))
 			return;
 		if (!fromRemote && !setDirect) {
-            publishChange(pObject, args);
+			publishChange(pObject, args);
 		} else {
 			object = pObject;
-            onChangeListeners.forEach((ocl) -> ocl.onChange(pObject, args));
+			onChangeListeners.forEach((ocl) -> ocl.onChange(pObject, args));
 			if (fromRemote)
-                onRemoteChangeListeners.forEach((ocl) -> ocl.onChange(pObject, args));
+				onRemoteChangeListeners.forEach((ocl) -> ocl.onChange(pObject, args));
 			else
-                publish(args);
+				publish(args);
 		}
 	}
 	
-    public String[] getArgsFromTopic(String topic) {
-        String[] topicSplit = topic.split("/");
-        String[] args = new String[wildcardPositions.length];
-        for (int i = 0; i < wildcardPositions.length; i++)
-            args[i] = topicSplit[wildcardPositions[i]];
-        return args;
-    }
+	public String[] getArgsFromTopic(String topic) {
+		String[] topicSplit = topic.split("/");
+		String[] args = new String[wildcardPositions.length];
+		for (int i = 0; i < wildcardPositions.length; i++)
+			args[i] = topicSplit[wildcardPositions[i]];
+		return args;
+	}
+	
 	public T get() {
 		return object;
 	}
 	
-    private void publish(Object... args) {
-        publishChange(object, args);
+	private void publish(Object... args) {
+		publishChange(object, args);
 	}
 	
-    private void publishChange(T pObject, Object... args) {
-        if (publishTopic != null) {
-            new Thread(() -> {
-                mqtt.publish(String.format(publishTopic, args),
-                        toString.apply(pObject),
-                        qos,
-                        retained);
-            }).start();
-        }
+	private void publishChange(T pObject, Object... args) {
+		if (publishTopic != null) {
+			new Thread(() -> {
+				mqtt.publish(String.format(publishTopic, args),
+					toPayload.apply(pObject),
+					qos,
+					retained);
+			}).start();
+		}
 	}
 	
 	private void subscribe() throws MqttException {
@@ -253,22 +262,24 @@ public class MqttObject<T> {
 		}
 	}
 	
-    public void removeOnChangeListener(OnChangeListener<T> onChangeListener) {
-        onChangeListeners.remove(onChangeListener);
-    }
+	public void removeOnChangeListener(OnChangeListener<T> onChangeListener) {
+		onChangeListeners.remove(onChangeListener);
+	}
+	
 	public void onChange(OnChangeListener<T> onChangeListener) {
 		onChangeListeners.add(onChangeListener);
 	}
 	
-    public void removeOnRemoteChangeListener(OnChangeListener<T> onChangeListener) {
-        onRemoteChangeListeners.remove(onChangeListener);
-    }
+	public void removeOnRemoteChangeListener(OnChangeListener<T> onChangeListener) {
+		onRemoteChangeListeners.remove(onChangeListener);
+	}
+	
 	public void onRemoteChange(OnChangeListener<T> onChangeListener) {
 		onRemoteChangeListeners.add(onChangeListener);
 	}
 	
 	public interface OnChangeListener<T> {
-        void onChange(T object, Object... args);
+		void onChange(T object, Object... args);
 	}
 	
 }

--- a/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
@@ -17,7 +17,6 @@ package org.zephyrsoft.sdb2.remote;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.slf4j.Logger;
@@ -128,7 +127,7 @@ public class RemoteController {
 				(a, b) -> false);
 			
 			healthDB = new MqttObject<>(mqtt, formatClientIDTopic(RemoteTopic.HEALTH_DB),
-				Health::valueOf, null, RemoteTopic.HEALTH_DB_QOS, RemoteTopic.HEALTH_DB_RETAINED, null);
+				Health::valueOfBytes, null, RemoteTopic.HEALTH_DB_QOS, RemoteTopic.HEALTH_DB_RETAINED, null);
 		} else {
 			this.playlist = null;
 			this.requestPatches = null;
@@ -181,18 +180,18 @@ public class RemoteController {
 		return remotePresenter;
 	}
 	
-	static Persistable parseXML(String xml) {
-		if (xml.isEmpty())
+	static Persistable parseXML(byte[] xml) {
+		if (xml.length == 0)
 			return null;
-		return XMLConverter.fromXMLToPersistable(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+		return XMLConverter.fromXMLToPersistable(new ByteArrayInputStream(xml));
 	}
 	
-	static String toXML(Persistable persistable) {
+	static byte[] toXML(Persistable persistable) {
 		if (persistable == null)
-			return "";
+			return new byte[0];
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		XMLConverter.fromPersistableToXML(persistable, baos, false, true);
-		return baos.toString(StandardCharsets.UTF_8);
+		return baos.toByteArray();
 	}
 	
 	/**

--- a/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
@@ -189,9 +189,14 @@ public class RemoteController {
 	static byte[] toXML(Persistable persistable) {
 		if (persistable == null)
 			return new byte[0];
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		XMLConverter.fromPersistableToXML(persistable, baos, false, true);
-		return baos.toByteArray();
+		try {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			XMLConverter.fromPersistableToXML(persistable, baos, false, true);
+			return baos.toByteArray();
+		} catch (IllegalStateException e) {
+			LOG.warn("Could convert persistable to payload.", e);
+		}
+		return null;
 	}
 	
 	/**


### PR DESCRIPTION
I found a critical encoding error in MQTT.java. Messages are converted from and to string with defaults platform encoding instead of utf-8. This is very critical as not every java platform has the same default encoding as i noticed.

I then moved the encoding handling two layers up to overcome duplicate encoding for xml objects and added a bit better exception handling for unparsable content.