### PR TITLE
chg: position visibility, active line

### DIFF
--- a/src/main/java/org/zephyrsoft/sdb2/gui/PartButtonGroup.java
+++ b/src/main/java/org/zephyrsoft/sdb2/gui/PartButtonGroup.java
@@ -193,4 +193,8 @@ public class PartButtonGroup extends JPanel {
 	protected boolean isActive() {
 		return active;
 	}
+	
+	public AddressablePart getPart() {
+		return part;
+	}
 }

--- a/src/main/java/org/zephyrsoft/sdb2/presenter/SongView.java
+++ b/src/main/java/org/zephyrsoft/sdb2/presenter/SongView.java
@@ -425,7 +425,8 @@ public class SongView extends JPanel implements Scroller {
 		Preconditions.checkArgument(parts != null, SONG_PARTS_NOT_INITIALIZED);
 		adjustHeightIfNecessary();
 		try {
-			AddressablePart addressablePart = parts.get(part);
+			int noTitlePart = showTitle ? part : Math.max(part - 1, 0);
+			AddressablePart addressablePart = parts.get(noTitlePart);
 			Preconditions.checkArgument(addressablePart != null, "part index does not correspond to a part of the song");
 			Rectangle2D target = text.modelToView2D(addressablePart.getPosition());
 			double targetY = target.getY();
@@ -443,7 +444,8 @@ public class SongView extends JPanel implements Scroller {
 		Preconditions.checkArgument(parts != null, SONG_PARTS_NOT_INITIALIZED);
 		adjustHeightIfNecessary();
 		try {
-			AddressablePart addressablePart = parts.get(part);
+			int noTitlePart = showTitle ? part : Math.max(part - 1, 0);
+			AddressablePart addressablePart = parts.get(noTitlePart);
 			Preconditions.checkArgument(addressablePart != null, "part index does not correspond to a part of the song");
 			AddressableLine addressableLine = addressablePart.get(line);
 			Preconditions.checkArgument(addressableLine != null, "line index does not correspond to a line of the addressed part");

--- a/src/main/java/org/zephyrsoft/sdb2/remote/MQTT.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/MQTT.java
@@ -34,7 +34,6 @@ public class MQTT implements MqttCallback {
 	private static final Logger LOG = LoggerFactory.getLogger(MQTT.class);
 	
 	private MqttClient client;
-	private String clientID;
 	private CopyOnWriteArrayList<OnMessageListener> onMessageListeners = new CopyOnWriteArrayList<>();
 	private CopyOnWriteArrayList<OnConnectionLostListener> onConnectionLostListeners = new CopyOnWriteArrayList<>();
 	
@@ -52,8 +51,6 @@ public class MQTT implements MqttCallback {
 	 * @throws MqttException
 	 */
 	public MQTT(String serverUri, String clientID, String userName, String password, boolean cleanSession) throws MqttException {
-		this.clientID = clientID;
-		
 		MqttConnectOptions mqttConnectOptions = new MqttConnectOptions();
 		if (!userName.isEmpty()) {
 			mqttConnectOptions.setUserName(userName);
@@ -121,10 +118,6 @@ public class MQTT implements MqttCallback {
 		} catch (MqttException e) {
 			// do nothing
 		}
-	}
-	
-	public String getClientID() {
-		return clientID;
 	}
 	
 	public void onMessage(OnMessageListener onMessageListener) {

--- a/src/main/java/org/zephyrsoft/sdb2/remote/MqttObject.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/MqttObject.java
@@ -60,24 +60,20 @@ public class MqttObject<T> {
 	 * can be null, if not set. toString must create a empty String to unset it. Attention: subcribers may not get the
 	 * empty string.
 	 *
-	 * @param mqtt
 	 * @param subscriptionTopic
 	 * @param toObject
 	 * @param toPayload
 	 * @param qos
 	 * @param retained
 	 * @param objectEquals
-	 * @throws MqttException
 	 */
-	public MqttObject(MQTT mqtt,
-		String subscriptionTopic,
+	public MqttObject(String subscriptionTopic,
 		Function<byte[], T> toObject,
 		Function<T, byte[]> toPayload,
 		int qos,
 		boolean retained,
-		BiPredicate<T, T> objectEquals) throws MqttException {
-		this(mqtt,
-			null,
+		BiPredicate<T, T> objectEquals) {
+		this(null,
 			subscriptionTopic,
 			toObject,
 			null,
@@ -101,19 +97,15 @@ public class MqttObject<T> {
 	 * can be null, if not set. toString must create a empty String to unset it. Attention: subcribers may not get the
 	 * empty string.
 	 *
-	 * @param mqtt
 	 * @param publishTopic
 	 * @param qos
 	 * @param retained
-	 * @throws MqttException
 	 */
-	public MqttObject(MQTT mqtt,
-		String publishTopic,
+	public MqttObject(String publishTopic,
 		Function<T, byte[]> toPayload,
 		int qos,
-		boolean retained) throws MqttException {
-		this(mqtt,
-			null,
+		boolean retained) {
+		this(null,
 			null,
 			null,
 			null,
@@ -137,10 +129,8 @@ public class MqttObject<T> {
 	 * can be null, if not set. toString must create a empty String to unset it. Attention: subcribers may not get the
 	 * empty string.
 	 *
-	 * @throws MqttException
 	 */
-	public MqttObject(MQTT mqtt,
-		T object,
+	public MqttObject(T object,
 		String subscriptionTopic,
 		Function<byte[], T> toObject,
 		BiPredicate<T, T> takeObject,
@@ -149,7 +139,7 @@ public class MqttObject<T> {
 		int qos,
 		boolean retained,
 		BiPredicate<T, T> objectEquals,
-		boolean setDirect) throws MqttException {
+		boolean setDirect) {
 		LOG.trace("new MqttObject: S: {} P: {}", subscriptionTopic, publishTopic);
 		this.subscriptionTopic = subscriptionTopic;
 		this.toObject = toObject;
@@ -210,8 +200,6 @@ public class MqttObject<T> {
 				set(newObject, true, (Object[]) getArgsFromTopic(topic));
 			}
 		};
-		
-		connectTo(mqtt);
 	}
 	
 	public void connectTo(MQTT pMqtt) throws MqttException {

--- a/src/main/java/org/zephyrsoft/sdb2/remote/PatchController.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/PatchController.java
@@ -123,10 +123,12 @@ public class PatchController extends SongsModelController {
 		currentVersionId = Long.parseLong(properties.getProperty(PREF_SONGS_VERSION_ID, "0"));
 		dbUUID = properties.getProperty(PREF_DB_UUID, "");
 		// Reset if prefix has changed:
-		if (!remoteController.getPrefix().equals(properties.getProperty(PREF_DB_PREFIX, remoteController.getPrefix())) ||
-			!remoteController.getServer().equals(properties.getProperty(PREF_DB_SERVER, remoteController.getServer())))
+		RemotePreferences remotePreferences = remoteController.getRemotePreferences();
+		if (!remotePreferences.getPrefix().equals(properties.getProperty(PREF_DB_PREFIX, remotePreferences.getPrefix())) ||
+			!remotePreferences.getServer().equals(properties.getProperty(PREF_DB_SERVER, remotePreferences.getServer())))
 			resetDB("");
-		LOG.debug("Loaded db for server " + remoteController.getServer() + "\\" + remoteController.getPrefix() + " and version: " + currentVersionId);
+		LOG.debug("Loaded db for server " + remotePreferences.getServer() + "\\" + remotePreferences.getPrefix() + " and version: "
+			+ currentVersionId);
 		
 		// Collect offline changes, align songs with db, and rebase changes later:
 		offlineChanges = collectChanges(songs);
@@ -364,7 +366,7 @@ public class PatchController extends SongsModelController {
 			long newVersionId = currentVersionId + 1;
 			String uuid = UUID.randomUUID().toString();
 			remoteController.getLatestChanges().set(new SongsModel(patchSongs, false),
-				remoteController.getUsername(), String.valueOf(newVersionId), uuid);
+				remoteController.getRemotePreferences().getUsername(), String.valueOf(newVersionId), uuid);
 		}
 	}
 	
@@ -459,9 +461,10 @@ public class PatchController extends SongsModelController {
 			LOG.debug("writing db to file \"{}\" and db properties to file \"{}\"", dbFile.getAbsolutePath(), dbPropertiesFile.getAbsolutePath());
 			XMLConverter.fromPersistableToXML(db, xmlOutputStream);
 			
+			RemotePreferences remotePreferences = remoteController.getRemotePreferences();
 			Properties properties = new Properties();
-			properties.setProperty(PREF_DB_PREFIX, remoteController.getPrefix());
-			properties.setProperty(PREF_DB_SERVER, remoteController.getServer());
+			properties.setProperty(PREF_DB_PREFIX, remotePreferences.getPrefix());
+			properties.setProperty(PREF_DB_SERVER, remotePreferences.getServer());
 			properties.setProperty(PREF_SONGS_VERSION_ID, String.valueOf(currentVersionId));
 			properties.setProperty(PREF_DB_UUID, dbUUID);
 			properties.storeToXML(new FileOutputStream(dbPropertiesFile), PREF_COMMENT);

--- a/src/main/java/org/zephyrsoft/sdb2/remote/Position.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/Position.java
@@ -35,6 +35,8 @@ public class Position implements Persistable {
 	private int part;
 	@XmlElement(name = "line")
 	private int line;
+	@XmlElement(name = "visibility")
+	private boolean visibility = true;
 	
 	public Position() {
 		initIfNecessary();
@@ -44,36 +46,50 @@ public class Position implements Persistable {
 	 * Part: 0 = Title, 1-N Parts
 	 */
 	public Position(String uuid, int part) {
-		this(uuid, part, 0);
+		this(uuid, part, 0, true);
 	}
 	
-	public Position(String uuid, int part, int line) {
+	public Position(String uuid, int part, int line, boolean visibility) {
 		this();
 		this.uuid = uuid;
 		this.part = part;
 		this.line = line;
+		this.visibility = visibility;
 	}
 	
-	public Position(String uuid, int part, int line, boolean partWithTitle) {
-		this(uuid, partWithTitle ? part : part + 1, line);
+	public Position(Position p) {
+		this();
+		this.uuid = p.uuid;
+		this.part = p.part;
+		this.line = p.line;
+		this.visibility = p.visibility;
 	}
 	
 	public int getPart() {
 		return part;
 	}
 	
-	public int getPart(boolean withTitle) {
-		return withTitle ? part : part - 1;
-	}
-	
 	public int getLine() {
 		return line;
+	}
+	
+	public boolean isVisible() {
+		return visibility;
+	}
+	
+	public boolean getVisibility() {
+		return visibility;
+	}
+	
+	public void setVisibility(boolean visibility) {
+		this.visibility = visibility;
 	}
 	
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof Position) {
-			return this.uuid.equals(((Position) obj).getUUID()) && this.part == ((Position) obj).getPart() && this.line == ((Position) obj).getLine();
+			return this.uuid.equals(((Position) obj).getUUID()) && this.part == ((Position) obj).getPart() && this.line == ((Position) obj).getLine()
+				&& this.visibility == ((Position) obj).getVisibility();
 		} else {
 			return false;
 		}

--- a/src/main/java/org/zephyrsoft/sdb2/remote/Position.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/Position.java
@@ -22,12 +22,24 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorOrder;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name = "position")
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlAccessorOrder(XmlAccessOrder.ALPHABETICAL)
 public class Position implements Persistable {
+	
+	@XmlType
+	@XmlEnum(String.class)
+	public enum Visibility {
+		@XmlEnumValue(value = "visible")
+		VISIBLE,
+		@XmlEnumValue(value = "blank")
+		BLANK;
+	}
 	
 	@XmlElement(name = "uuid")
 	private String uuid;
@@ -36,7 +48,7 @@ public class Position implements Persistable {
 	@XmlElement(name = "line")
 	private int line;
 	@XmlElement(name = "visibility")
-	private boolean visibility = true;
+	private Visibility visibility;
 	
 	public Position() {
 		initIfNecessary();
@@ -46,23 +58,32 @@ public class Position implements Persistable {
 	 * Part: 0 = Title, 1-N Parts
 	 */
 	public Position(String uuid, int part) {
-		this(uuid, part, 0, true);
+		this(uuid, part, 0, null);
 	}
 	
-	public Position(String uuid, int part, int line, boolean visibility) {
+	public Position(String uuid, int part, int line) {
+		this(uuid, part, line, null);
+	}
+	
+	public Position(String uuid, int part, int line, Visibility visibility) {
 		this();
 		this.uuid = uuid;
 		this.part = part;
 		this.line = line;
-		this.visibility = visibility;
+		if (visibility == Visibility.VISIBLE)
+			this.visibility = null;
+		else
+			this.visibility = visibility;
+	}
+	
+	public Position(Position p, Visibility visibility) {
+		this(p != null ? p.uuid : null,
+			p != null ? p.part : 0,
+			p != null ? p.line : 0, visibility);
 	}
 	
 	public Position(Position p) {
-		this();
-		this.uuid = p.uuid;
-		this.part = p.part;
-		this.line = p.line;
-		this.visibility = p.visibility;
+		this(p.uuid, p.part, p.line, p.visibility);
 	}
 	
 	public int getPart() {
@@ -74,15 +95,11 @@ public class Position implements Persistable {
 	}
 	
 	public boolean isVisible() {
-		return visibility;
+		return visibility == null || visibility == Visibility.VISIBLE;
 	}
 	
-	public boolean getVisibility() {
+	public Visibility getVisibility() {
 		return visibility;
-	}
-	
-	public void setVisibility(boolean visibility) {
-		this.visibility = visibility;
 	}
 	
 	@Override

--- a/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
@@ -107,7 +107,7 @@ public class RemoteController {
 				RemoteController::toXML, RemoteTopic.PATCHES_REQUEST_PATCHES_QOS, RemoteTopic.PATCHES_REQUEST_PATCHES_RETAINED,
 				(a, b) -> false);
 			
-			healthDB = new MqttObject<>(formatClientIDTopic(RemoteTopic.HEALTH_DB),
+			healthDB = new MqttObject<>(formatPrefixTopic(RemoteTopic.HEALTH_DB),
 				Health::valueOfBytes, null, RemoteTopic.HEALTH_DB_QOS, RemoteTopic.HEALTH_DB_RETAINED, null);
 		} else {
 			this.playlist = null;
@@ -220,6 +220,10 @@ public class RemoteController {
 	private String formatClientIDTopic(String topic) {
 		return String.format(topic, getRemotePreferences().getPrefix().isBlank() ? "" : getRemotePreferences().getPrefix() + "/", remotePreferences
 			.getClientID());
+	}
+	
+	private String formatPrefixTopic(String topic) {
+		return String.format(topic, getRemotePreferences().getPrefix().isEmpty() ? "" : getRemotePreferences().getPrefix() + "/");
 	}
 	
 	public MqttObject<Version> getLatestVersion() {

--- a/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/RemoteController.java
@@ -27,15 +27,13 @@ import org.zephyrsoft.sdb2.model.Persistable;
 import org.zephyrsoft.sdb2.model.Song;
 import org.zephyrsoft.sdb2.model.SongsModel;
 import org.zephyrsoft.sdb2.model.XMLConverter;
-import org.zephyrsoft.sdb2.model.settings.SettingKey;
-import org.zephyrsoft.sdb2.model.settings.SettingsModel;
 import org.zephyrsoft.sdb2.presenter.Presentable;
+import org.zephyrsoft.sdb2.util.StringTools;
 
 public class RemoteController {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(RemoteController.class);
 	
-	private final MQTT mqtt;
 	private final MqttObject<Song> song;
 	private final MqttObject<Position> position;
 	private final MqttObject<SongsModel> playlist;
@@ -46,12 +44,7 @@ public class RemoteController {
 	private final MqttObject<ChangeReject> latestReject;
 	private final MqttObject<Health> healthDB;
 	private final RemotePresenter remotePresenter;
-	private final String prefix;
-	private final String room;
-	private final String server;
-	private final String username;
-	private final String password;
-	private final boolean showTitle;
+	private RemotePreferences remotePreferences;
 	
 	/**
 	 * Creates a RemoteController instance by connecting to a broker and setting up properties.
@@ -70,63 +63,51 @@ public class RemoteController {
 	 * @param mainWindow
 	 *            can be null, if headless
 	 */
-	public RemoteController(SettingsModel settingsModel, MainController mainController, MainWindow mainWindow) throws MqttException {
-		prefix = settingsModel.get(SettingKey.REMOTE_PREFIX, String.class);
-		room = settingsModel.get(SettingKey.REMOTE_NAMESPACE, String.class);
-		server = settingsModel.get(SettingKey.REMOTE_SERVER, String.class);
-		username = settingsModel.get(SettingKey.REMOTE_USERNAME, String.class);
-		password = settingsModel.get(SettingKey.REMOTE_PASSWORD, String.class);
-		showTitle = settingsModel.get(SettingKey.SHOW_TITLE, Boolean.class);
+	public RemoteController(RemotePreferences remotePreferences, MainController mainController, MainWindow mainWindow) {
+		this.remotePreferences = remotePreferences;
 		
-		mqtt = new MQTT(server, username, password, true);
-		
-		mqtt.onConnectionLost(cause -> {
-			mainController.setRemoteStatus(RemoteStatus.FAILURE);
-			cause.printStackTrace();
-		});
-		
-		position = new MqttObject<>(mqtt, formatTopic(RemoteTopic.POSITION), (s) -> (Position) parseXML(s),
+		position = new MqttObject<>(formatTopic(RemoteTopic.POSITION), (s) -> (Position) parseXML(s),
 			RemoteController::toXML, RemoteTopic.POSITION_QOS, RemoteTopic.POSITION_RETAINED,
 			null);
-		position.onRemoteChange((p, a) -> handleSongPositionChange(mainController, p));
+		position.onRemoteChange((p, a) -> updateSongOrPosition(mainController, mainWindow));
 		
-		song = new MqttObject<>(mqtt, formatTopic(RemoteTopic.SONG),
+		song = new MqttObject<>(formatTopic(RemoteTopic.SONG),
 			(s) -> (Song) parseXML(s), RemoteController::toXML, RemoteTopic.SONG_QOS, RemoteTopic.SONG_RETAINED,
 			null);
-		song.onRemoteChange((s, a) -> handleSongChange(mainController, mainWindow, s));
+		song.onRemoteChange((s, a) -> updateSongOrPosition(mainController, mainWindow));
 		
 		if (mainWindow != null) {
-			playlist = new MqttObject<>(mqtt, formatTopic(RemoteTopic.PLAYLIST),
+			playlist = new MqttObject<>(formatTopic(RemoteTopic.PLAYLIST),
 				(s) -> (SongsModel) parseXML(s),
 				RemoteController::toXML, RemoteTopic.PLAYLIST_QOS, RemoteTopic.PLAYLIST_RETAINED,
 				null);
 			playlist.onRemoteChange((p, a) -> mainWindow.updatePlaylist(p));
 			mainWindow.getPresentModel().addSongsModelListener(() -> playlist.set(new SongsModel(mainWindow.getPresentModel())));
 			
-			latestVersion = new MqttObject<>(mqtt, formatTopic(RemoteTopic.PATCHES_LATEST_VERSION),
+			latestVersion = new MqttObject<>(formatTopic(RemoteTopic.PATCHES_LATEST_VERSION),
 				(s) -> (Version) parseXML(s),
 				RemoteController::toXML, RemoteTopic.PATCHES_LATEST_VERSION_QOS, RemoteTopic.PATCHES_LATEST_VERSION_RETAINED,
 				(a, b) -> false);
 			
-			latestChanges = new MqttObject<>(mqtt, formatTopic(RemoteTopic.PATCHES_LATEST_CHANGES),
+			latestChanges = new MqttObject<>(formatTopic(RemoteTopic.PATCHES_LATEST_CHANGES),
 				(s) -> (SongsModel) parseXML(s),
 				RemoteController::toXML, RemoteTopic.PATCHES_LATEST_CHANGES_QOS, RemoteTopic.PATCHES_LATEST_CHANEGS_RETAINED,
 				(a, b) -> false);
 			
-			latestReject = new MqttObject<>(mqtt, formatTopic(RemoteTopic.PATCHES_LATEST_REJECT),
+			latestReject = new MqttObject<>(formatTopic(RemoteTopic.PATCHES_LATEST_REJECT),
 				(s) -> (ChangeReject) parseXML(s),
 				null, RemoteTopic.PATCHES_LATEST_REJECT_QOS, RemoteTopic.PATCHES_LATEST_REJECT_RETAINED,
 				(a, b) -> false);
 			
-			requestGet = new MqttObject<>(mqtt, formatClientIDTopic(RemoteTopic.PATCHES_REQUEST_GET),
+			requestGet = new MqttObject<>(formatClientIDTopic(RemoteTopic.PATCHES_REQUEST_GET),
 				RemoteController::toXML, RemoteTopic.PATCHES_REQUEST_GET_QOS, RemoteTopic.PATCHES_REQUEST_GET_RETAINED);
 			
-			requestPatches = new MqttObject<>(mqtt, formatClientIDTopic(RemoteTopic.PATCHES_REQUEST_PATCHES),
+			requestPatches = new MqttObject<>(formatClientIDTopic(RemoteTopic.PATCHES_REQUEST_PATCHES),
 				(s) -> (Patches) parseXML(s),
 				RemoteController::toXML, RemoteTopic.PATCHES_REQUEST_PATCHES_QOS, RemoteTopic.PATCHES_REQUEST_PATCHES_RETAINED,
 				(a, b) -> false);
 			
-			healthDB = new MqttObject<>(mqtt, formatClientIDTopic(RemoteTopic.HEALTH_DB),
+			healthDB = new MqttObject<>(formatClientIDTopic(RemoteTopic.HEALTH_DB),
 				Health::valueOfBytes, null, RemoteTopic.HEALTH_DB_QOS, RemoteTopic.HEALTH_DB_RETAINED, null);
 		} else {
 			this.playlist = null;
@@ -138,28 +119,60 @@ public class RemoteController {
 			this.healthDB = null;
 		}
 		
-		remotePresenter = new RemotePresenter(this, showTitle);
+		remotePresenter = new RemotePresenter(this);
 	}
 	
-	private void handleSongChange(MainController mainController, MainWindow mainWindow, Song newSong) {
-		if (mainWindow != null)
-			mainWindow.present(newSong);
-		else
-			mainController.present(new Presentable(newSong, null));
-		// if(song != null)
-		// handleSongPositionChange(mainController, mainWindow, position.get());
+	public void connectTo(MQTT mqtt) throws MqttException {
+		song.connectTo(mqtt);
+		position.connectTo(mqtt);
+		playlist.connectTo(mqtt);
+		latestVersion.connectTo(mqtt);
+		latestChanges.connectTo(mqtt);
+		requestGet.connectTo(mqtt);
+		requestPatches.connectTo(mqtt);
+		latestReject.connectTo(mqtt);
+		healthDB.connectTo(mqtt);
 	}
 	
-	private void handleSongPositionChange(MainController mainController, Position p) {
-		if (p == null) {
-			// handleSongChange(mainController, mainWindow, null);
+	private void updateSongOrPosition(MainController mainController, MainWindow mainWindow) {
+		if (position == null || song == null)
 			return;
-		} else if (song != null && song.get() != null && song.get().getUUID() != null && song.get().getUUID().equals(p.getUUID())) {
-			try {
-				mainController.moveToLine(p.getPart(showTitle), p.getLine());
-			} catch (IndexOutOfBoundsException e) {
-				LOG.warn("Part or line out of bounds!");
+		Position p = position.get();
+		if (p == null) {
+			// presentSong(mainController, mainWindow, null);
+			return;
+		}
+		Song s = song.get();
+		if (s == null) {
+			return;
+		}
+		
+		if (StringTools.equals(s.getUUID(), p.getUUID())) {
+			if (p.isVisible()) {
+				presentSong(mainController, mainWindow, s);
+				moveToLine(mainController, mainWindow, p);
+			} else {
+				presentSong(mainController, mainWindow, null);
 			}
+		}
+	}
+	
+	private void presentSong(MainController mainController, MainWindow mainWindow, Song s) {
+		if (mainWindow != null)
+			mainWindow.present(s);
+		else
+			mainController.present(new Presentable(s, null));
+	}
+	
+	private void moveToLine(MainController mainController, MainWindow mainWindow, Position p) {
+		int part = p.getPart();
+		try {
+			mainController.moveToLine(part, p.getLine());
+		} catch (IndexOutOfBoundsException e) {
+			LOG.warn("Part or line out of bounds!");
+		}
+		if (mainWindow != null) {
+			mainWindow.setActiveLine(part, p.getLine());
 		}
 	}
 	
@@ -199,30 +212,14 @@ public class RemoteController {
 		return null;
 	}
 	
-	/**
-	 * Closes the mqtt connection.
-	 */
-	public void close() {
-		mqtt.close();
-	}
-	
 	private String formatTopic(String topic) {
-		return String.format(topic, prefix.isBlank() ? "" : prefix + "/", room);
+		return String.format(topic, getRemotePreferences().getPrefix().isBlank() ? "" : getRemotePreferences().getPrefix() + "/",
+			getRemotePreferences().getRoom());
 	}
 	
 	private String formatClientIDTopic(String topic) {
-		return String.format(topic, prefix.isBlank() ? "" : prefix + "/", mqtt.getClientID());
-	}
-	
-	public boolean checkSettingsChanged(SettingsModel settings) {
-		String sPrefix = settings.get(SettingKey.REMOTE_PREFIX, String.class);
-		String sRoom = settings.get(SettingKey.REMOTE_NAMESPACE, String.class);
-		String sServer = settings.get(SettingKey.REMOTE_SERVER, String.class);
-		String sUsername = settings.get(SettingKey.REMOTE_USERNAME, String.class);
-		String sPassword = settings.get(SettingKey.REMOTE_PASSWORD, String.class);
-		
-		return !sPrefix.equals(prefix) || !sRoom.equals(room) || !sServer.equals(server) || !sUsername.equals(sUsername) || !sPassword
-			.equals(password);
+		return String.format(topic, getRemotePreferences().getPrefix().isBlank() ? "" : getRemotePreferences().getPrefix() + "/", remotePreferences
+			.getClientID());
 	}
 	
 	public MqttObject<Version> getLatestVersion() {
@@ -249,16 +246,8 @@ public class RemoteController {
 		return healthDB;
 	}
 	
-	public String getPrefix() {
-		return prefix;
-	}
-	
-	public String getUsername() {
-		return username;
-	}
-	
-	public String getServer() {
-		return server;
+	public RemotePreferences getRemotePreferences() {
+		return remotePreferences;
 	}
 	
 }

--- a/src/main/java/org/zephyrsoft/sdb2/remote/RemotePreferences.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/RemotePreferences.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Song Database (SDB).
+ *
+ * SDB is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License 3.0 as published by
+ * the Free Software Foundation.
+ *
+ * SDB is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License 3.0 for more details.
+ *
+ * You should have received a copy of the GNU General Public License 3.0
+ * along with SDB. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.zephyrsoft.sdb2.remote;
+
+/**
+ * 
+ */
+public interface RemotePreferences {
+	
+	public String getPrefix();
+	
+	public String getRoom();
+	
+	public String getServer();
+	
+	public String getUsername();
+	
+	public String getPassword();
+	
+	public String getClientID();
+}

--- a/src/main/java/org/zephyrsoft/sdb2/remote/RemotePresenter.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/RemotePresenter.java
@@ -64,7 +64,7 @@ public class RemotePresenter implements Presenter {
 	@Override
 	public void moveToLine(Integer part, Integer line) {
 		if (presentable.getSong() != null) {
-			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), part, line, true));
+			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), part, line));
 		}
 	}
 	
@@ -87,17 +87,12 @@ public class RemotePresenter implements Presenter {
 		
 		if (presentable.getSong() != null) {
 			remoteController.getSong().set(presentable.getSong());
-			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), 0, 0, true));
+			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), 0, 0));
 		} else if (presentable.getImage() != null) {
 			LOG.warn("Images are not presented over remote");
 		} else {
 			// display a blank screen: // hidePresenter();
-			Position p = remoteController.getPosition().get();
-			if (p != null) {
-				Position invisiblePosition = new Position(p);
-				invisiblePosition.setVisibility(false);
-				remoteController.getPosition().set(invisiblePosition);
-			}
+			remoteController.getPosition().set(new Position(remoteController.getPosition().get(), Position.Visibility.BLANK));
 		}
 	}
 	

--- a/src/main/java/org/zephyrsoft/sdb2/remote/RemotePresenter.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/RemotePresenter.java
@@ -34,13 +34,11 @@ public class RemotePresenter implements Presenter {
 	
 	private Presentable presentable;
 	private final RemoteController remoteController;
-	private final boolean showTitle;
 	
 	// private ArrayList parts;
 	
-	public RemotePresenter(RemoteController remoteController, boolean showTitle) {
+	public RemotePresenter(RemoteController remoteController) {
 		this.remoteController = remoteController;
-		this.showTitle = showTitle;
 	}
 	
 	@Override
@@ -66,7 +64,7 @@ public class RemotePresenter implements Presenter {
 	@Override
 	public void moveToLine(Integer part, Integer line) {
 		if (presentable.getSong() != null) {
-			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), part, line, showTitle));
+			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), part, line, true));
 		}
 	}
 	
@@ -89,13 +87,17 @@ public class RemotePresenter implements Presenter {
 		
 		if (presentable.getSong() != null) {
 			remoteController.getSong().set(presentable.getSong());
-			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), 0, 0));
+			remoteController.getPosition().set(new Position(presentable.getSong().getUUID(), 0, 0, true));
 		} else if (presentable.getImage() != null) {
 			LOG.warn("Images are not presented over remote");
 		} else {
 			// display a blank screen: // hidePresenter();
-			remoteController.getSong().set(null);
-			remoteController.getPosition().set(null);
+			Position p = remoteController.getPosition().get();
+			if (p != null) {
+				Position invisiblePosition = new Position(p);
+				invisiblePosition.setVisibility(false);
+				remoteController.getPosition().set(invisiblePosition);
+			}
 		}
 	}
 	

--- a/src/main/java/org/zephyrsoft/sdb2/remote/SDB2RemotePreferences.java
+++ b/src/main/java/org/zephyrsoft/sdb2/remote/SDB2RemotePreferences.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the Song Database (SDB).
+ *
+ * SDB is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License 3.0 as published by
+ * the Free Software Foundation.
+ *
+ * SDB is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License 3.0 for more details.
+ *
+ * You should have received a copy of the GNU General Public License 3.0
+ * along with SDB. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.zephyrsoft.sdb2.remote;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.zephyrsoft.sdb2.model.settings.SettingKey;
+import org.zephyrsoft.sdb2.model.settings.SettingsModel;
+
+/**
+ * 
+ */
+public class SDB2RemotePreferences implements RemotePreferences {
+	
+	private String prefix;
+	private String room;
+	private String server;
+	private String username;
+	private String password;
+	private String clientID;
+	
+	public SDB2RemotePreferences(SettingsModel settingsModel) {
+		prefix = settingsModel.get(SettingKey.REMOTE_PREFIX, String.class);
+		room = settingsModel.get(SettingKey.REMOTE_NAMESPACE, String.class);
+		server = settingsModel.get(SettingKey.REMOTE_SERVER, String.class);
+		username = settingsModel.get(SettingKey.REMOTE_USERNAME, String.class);
+		password = settingsModel.get(SettingKey.REMOTE_PASSWORD, String.class);
+		clientID = UUID.randomUUID().toString();
+	}
+	
+	/**
+	 * @see org.zephyrsoft.sdb2.remote.RemotePreferences#getPrefix()
+	 */
+	@Override
+	public String getPrefix() {
+		return prefix;
+	}
+	
+	/**
+	 * @see org.zephyrsoft.sdb2.remote.RemotePreferences#getRoom()
+	 */
+	@Override
+	public String getRoom() {
+		return room;
+	}
+	
+	/**
+	 * @see org.zephyrsoft.sdb2.remote.RemotePreferences#getServer()
+	 */
+	@Override
+	public String getServer() {
+		return server;
+	}
+	
+	/**
+	 * @see org.zephyrsoft.sdb2.remote.RemotePreferences#getUsername()
+	 */
+	@Override
+	public String getUsername() {
+		return username;
+	}
+	
+	/**
+	 * @see org.zephyrsoft.sdb2.remote.RemotePreferences#getPassword()
+	 */
+	@Override
+	public String getPassword() {
+		return password;
+	}
+	
+	/**
+	 * @see org.zephyrsoft.sdb2.remote.RemotePreferences#getClientID()
+	 */
+	@Override
+	public String getClientID() {
+		return clientID;
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		SDB2RemotePreferences that = (SDB2RemotePreferences) o;
+		return Objects.equals(getPrefix(), that.getPrefix()) && Objects.equals(getRoom(), that.getRoom()) && Objects.equals(getServer(), that
+			.getServer()) && Objects.equals(getUsername(), that.getUsername()) && Objects.equals(getPassword(), that.getPassword());
+	}
+}


### PR DESCRIPTION
Fixes for:
- Button enable state is now updated on playlist change
- Playlist selection is now maintained during playlist change
- DB health with has now the right prefix for prefixed connections

Improvements:
- Blank is now encoded as position visibility instead of null song and null position. This allows a unblank action in future to show the last active song jump to its line.
- Split remotecontroller from it's settings to make it more general.
- Changed to explicit mqttobject connection, to set up listeners first, and connect then.
- Title dependent position is now set for the partbuttongroup instead of the extended position class.